### PR TITLE
Update code.js

### DIFF
--- a/code.js
+++ b/code.js
@@ -91,7 +91,7 @@ function shapeSpacerComponent(component, size) {
     var text = figma.createText();
     component.appendChild(text);
     text.name = LabelName;
-    figma.loadFontAsync({ family: "Roboto", style: "Regular" }).then(msg => {
+    figma.loadFontAsync(text.fontName).then(msg => {
         if (containerSize < 16) {
             text.fontSize = containerSize - Math.round(containerSize * 0.2);
         }


### PR DESCRIPTION
Fixed an error where the spacer size label isn't rendering in the spacer. Thought maybe there's an issue with trying to pull in a custom font like Roboto or perhaps an issue with loadFontAsync implementation, so instead it's pulling just the default interface font (line 94). Seems to work!